### PR TITLE
json_result can return a list not dict

### DIFF
--- a/moodle_inscribe/__main__.py
+++ b/moodle_inscribe/__main__.py
@@ -56,7 +56,11 @@ def get_student(host, course_id, student_email, sesskey, enrol_id, moodle_sessio
     }]
 
     json_result = moodle_post(host, sesskey, data, moodle_session)
-    users = [user for user in json_result['users'] if user['email'] == student_email]
+
+    if isinstance(json_result, dict):
+        json_result = json_result['users']
+
+    users = [user for user in json_result if user['email'] == student_email]
     if len(users) == 0:
         return None
     elif len(users) == 1:


### PR DESCRIPTION
The moodle call for me returns a list with the user dict inside when
calling it with a single student email. This fixes it to handle this
situation.